### PR TITLE
Plotting x coordinate selection support

### DIFF
--- a/DAQ/Plotting.py
+++ b/DAQ/Plotting.py
@@ -206,25 +206,36 @@ class Plotter(tk.Frame):
         self.dev_var.set(self.dev_list[0])
         dev_select = tk.OptionMenu(self.f, self.dev_var, *self.dev_list,
                 command=self.refresh_parameter_list)
-        dev_select.grid(row=0, column=0, sticky='ew')
+        dev_select.grid(row=0, column=0, columnspan=1, sticky='ew')
         dev_select.configure(width=18)
-
-        # select parameter
-        self.param_list = ["(select device first)"]
-        self.param_var = tk.StringVar()
-        self.param_var.set("Select what to plot ...")
-        self.param_select = tk.OptionMenu(self.f, self.param_var, *self.param_list)
-        self.param_select.grid(row=0, column=1, sticky='ew')
-        self.param_select.configure(width=20)
-        self.refresh_parameter_list(self.dev_var.get())
 
         # select run
         self.run_list = [""]
         self.run_var = tk.StringVar()
         self.run_var.set("Select run ...")
         self.run_select = tk.OptionMenu(self.f, self.run_var, *self.run_list)
-        self.run_select.grid(row=1, column=0, columnspan=2, sticky='ew')
-        self.run_select.configure(width=38)
+        self.run_select.grid(row=0, column=1, columnspan=1, sticky='ew')
+        self.run_select.configure(width=18)
+
+        # select parameter
+        self.param_list = ["(select device first)"]
+        self.param_var = tk.StringVar()
+        self.param_var.set("y ...")
+        self.param_select = tk.OptionMenu(self.f, self.param_var, *self.param_list)
+        self.param_select.grid(row=1, column=1, columnspan=1, sticky='ew')
+        self.param_select.configure(width=18)
+
+        # select xcol
+        self.xcol_list = ["(select device first)"]
+        self.xcol_var = tk.StringVar()
+        self.xcol_var.set("x ...")
+        self.xcol_select = tk.OptionMenu(self.f, self.xcol_var, *self.xcol_list)
+        self.xcol_select.grid(row=1, column=0, columnspan=1, sticky='ew')
+        self.xcol_select.configure(width=18)
+
+        self.refresh_parameter_list(self.dev_var.get())
+
+
 
         # plot range controls
         num_width = 6 # width of numeric entry boxes
@@ -365,6 +376,13 @@ class Plotter(tk.Frame):
         for p in self.param_list:
             menu.add_command(label=p, command=lambda val=p: self.param_var.set(val))
 
+        # update xcol list
+        self.xcol_list = ["None"]+self.param_list.copy()
+        menu = self.xcol_select["menu"]
+        menu.delete(0, "end")
+        for p in self.xcol_list:
+            menu.add_command(label=p, command=lambda val=p: self.xcol_var.set(val))
+
     def get_data(self):
         # check device is valid
         if self.dev_var.get() in self.parent.devices:
@@ -473,14 +491,18 @@ class Plotter(tk.Frame):
                         y = dset[:, self.param_list.index(param)]
 
             # if displaying data as recorded (not evaluating a function of the data)
-            else: 
+            else:
                 if dev.config["single_dataset"]:
                     try:
                         dset = grp[dev.config["name"]]
                     except KeyError as err:
                         messagebox.showerror("Data error", "Dataset not found in this run.")
                         return None
-                    x = dset[:, 0]
+                    print(type(self.xcol_var.get()), self.xcol_var.get())
+                    if self.xcol_var.get() == "None":
+                        x = np.arange(dset.shape[0])
+                    else:
+                        x = dset[:, self.param_list.index(self.xcol_var.get())]
                     y = dset[:, self.param_list.index(param)]
                 else: # if each acquisition is its own dataset, return latest run only
                     rec_num = len(grp) - 1

--- a/DAQ/config/beam_source/CTC100.ini
+++ b/DAQ/config/beam_source/CTC100.ini
@@ -155,7 +155,7 @@ row = 16
 col = 0
 argument =
 command = outputEnable
-align =  
+align =
 
 [outputDisable]
 label = Disable Output
@@ -164,4 +164,4 @@ row = 16
 col = 1
 argument =
 command = outputDisable
-align =  
+align =

--- a/DAQ/config/electrostatic_lens/labjackT7.ini
+++ b/DAQ/config/electrostatic_lens/labjackT7.ini
@@ -1,0 +1,115 @@
+[device]
+name = labjackT7
+label = Labjack T7 Pro
+path = electrostatic_lens
+driver = labjackT7
+constr_params = IP_address, sampling, channels
+correct_response = 7
+single_dataset = True
+row = 1
+column = 0
+rowspan = 1
+columnspan = 1
+monitoring_row = 1
+monitoring_column = 0
+
+[attributes]
+column_names = ch2
+units = binary
+
+[enabled]
+label = Device enabled
+type = Checkbutton
+row = 0
+col = 1
+value = 1
+
+[HDF_enabled]
+label = HDF enabled
+type = Checkbutton
+row = 0
+col = 2
+value = 1
+
+[dt]
+label = Loop delay [s]
+type = Entry
+row = 1
+col = 1
+value = 0.25
+width = 5
+
+[IP_address]
+label = IP address
+type = Entry
+row = 2
+col = 1
+value = 172.28.169.152
+options =
+command =
+
+[channels]
+label = Channels
+type = ControlsTable
+column_names = enable, channel
+column_labels = , Input, Range, Coupling
+column_types = Checkbutton, Label
+column_widths = 10, 10, 5, 3
+column_options = ...; ...;
+column_values = 1,1,1,1,1,1; V1,V2,I1,I2,VDIV1,VDIV2;
+row_ids = 0, 1, 2, 3, 4, 5
+row = 4
+col = 6
+rowspan=6
+columnspan=1
+
+[sampling]
+label = Sampling
+type = ControlsRow
+control_names = scans_rate, scans_per_read
+control_labels = Sample rate [S/s], Scans per read [S/r]
+control_types = Entry, Entry
+control_widths = 7, 7
+control_values = 50, 25
+control_options = ...; ...;
+row = 3
+col = 1
+
+[hv_enable]
+label = HV Enable
+type = ControlsRow
+control_names = hv1_enable, hv2_enable
+control_labels = HV 1, HV 2
+control_types = CheckbuttonCmd, CheckbuttonCmd
+control_commands = HV1Enable, HV2Enable
+control_widths = 7, 7
+control_values = 0, 0
+control_options = ...; ...;
+row = 4
+col = 1
+
+[polarity]
+label = Polarity
+type = ControlsRow
+control_names = polarity1, polarity2, polarity_set
+control_labels = HV 1, HV 2, Set
+control_types = OptionMenu, OptionMenu, Button
+control_widths = 7,7,3
+control_values = POS, NEG,
+control_options = POS,NEG;POS,NEG;
+control_commands = ,, SetPolarity
+row = 5
+col = 1
+
+[set_hv]
+label = Set Voltage
+type = ControlsRow
+control_names = hv1_v, hv2_v, ramp, ramp_time, voltage_set
+control_labels = HV 1 [kV], HV 2 [kV], Ramp, Ramp Time [s], Set
+control_types = Entry, Entry, Checkbutton, Entry, Button
+control_widths = 7,7,7,7,3
+control_values = 0,0,0,0,
+control_options = ...;...;...;...;...;
+control_commands = ,,,,SetVoltage
+row = 6
+col = 1

--- a/DAQ/config/electrostatic_lens/labjackT7.ini
+++ b/DAQ/config/electrostatic_lens/labjackT7.ini
@@ -14,8 +14,8 @@ monitoring_row = 1
 monitoring_column = 0
 
 [attributes]
-column_names = ch2
-units = binary
+column_names = V1,V2,I1,I2,VDIV1,VDIV2
+units = V,V,V,V,V,V
 
 [enabled]
 label = Device enabled

--- a/DAQ/config/settings.ini
+++ b/DAQ/config/settings.ini
@@ -4,9 +4,8 @@ hdf_loop_delay = .25
 
 [files]
 #config_dir = c:/Users/CENTREX/Documents/centrex/software/DAQ/config/readout
-#config_dir = c:/Users/CENTREX/Documents/centrex/software/DAQ/config/beam_source
-config_dir = C:/Users/CeNTREX/Documents/CeNTREX/DAQ/config/electrostatic_lens
-hdf_fname = C:/Users/CeNTREX/Documents/Data/slow_data_test.h5
+config_dir = c:/Users/CENTREX/Documents/centrex/software/DAQ/config/beam_source
+hdf_fname = C:/Users/CENTREX/Documents/centrex/data/slow_data_test.h5
 plotting_hdf_fname = C:/Users/CENTREX/Documents/centrex/data/slow_data_test.h5
 
 [influxdb]

--- a/DAQ/config/settings.ini
+++ b/DAQ/config/settings.ini
@@ -4,8 +4,9 @@ hdf_loop_delay = .25
 
 [files]
 #config_dir = c:/Users/CENTREX/Documents/centrex/software/DAQ/config/readout
-config_dir = c:/Users/CENTREX/Documents/centrex/software/DAQ/config/beam_source
-hdf_fname = C:/Users/CENTREX/Documents/centrex/data/slow_data_test.h5
+#config_dir = c:/Users/CENTREX/Documents/centrex/software/DAQ/config/beam_source
+config_dir = C:/Users/CeNTREX/Documents/CeNTREX/DAQ/config/electrostatic_lens
+hdf_fname = C:/Users/CeNTREX/Documents/Data/slow_data_test.h5
 plotting_hdf_fname = C:/Users/CENTREX/Documents/centrex/data/slow_data_test.h5
 
 [influxdb]

--- a/DAQ/drivers/PXIe5171.py
+++ b/DAQ/drivers/PXIe5171.py
@@ -93,6 +93,7 @@ class PXIe5171:
         self.new_attributes = [
                     ("column_names", ", ".join(["ch"+str(x) for x in self.active_channels])),
                     ("units", ", ".join(["binary" for x in self.active_channels])),
+                    ("sampling", str(1000*samplingRate_kSs)+" [S/s]")
                ]
 
         # shape and type of the array of returned data

--- a/DAQ/drivers/labjackT7.py
+++ b/DAQ/drivers/labjackT7.py
@@ -1,0 +1,119 @@
+from labjack.ljm import openS, eReadName, eWriteName, eWriteNames, eStreamStart,\
+                        getHandleInfo, constants, namesToAddresses, eStreamStop,\
+                        eStreamRead
+from labjack import ljm
+import numpy as np
+import time
+import sys
+import datetime
+import logging
+
+class labjackT7:
+    def __init__(self, time_offset, IP_address, sampling, channels):
+
+        self.hv1_enable = 0
+        self.hv2_enable = 0
+        self.handle = openS("T7","ETHERNET",IP_address)
+        self.HV1Enable()
+        self.HV2Enable()
+        try:
+            eStreamStop(self.handle)
+        except ljm.LJMError as exception:
+            if exception.errorString != "STREAM_NOT_RUNNING":
+                raise
+
+        self.time_offset = time_offset
+
+        try:
+            self.verification_string = str(getHandleInfo(self.handle)[0])
+        except:
+            self.verification_string = "False"
+
+
+        # Ensure triggered stream is disabled.
+        eWriteName(self.handle, "STREAM_TRIGGER_INDEX", 0)
+
+        # Enabling internally-clocked stream.
+        eWriteName(self.handle, "STREAM_CLOCK_SOURCE", 0)
+
+        # Configure the analog input negative channels, ranges, stream settling
+        # times and stream resolution index.
+        aNames = ["AIN_ALL_NEGATIVE_CH", "AIN_ALL_RANGE", "STREAM_SETTLING_US",
+                  "STREAM_RESOLUTION_INDEX"]
+        aValues = [constants.GND, 10.0, 0, 0]  # single-ended, +/-10V, 0 (default), 0 (default)
+        eWriteNames(self.handle, len(aNames), aNames, aValues)
+
+        # start acquisition
+        self.active_channels = []
+        self.active_channel_names = []
+        for ch in [0,1,2,3,4,5]:
+            if bool(int(channels[0][ch].get())):
+                self.active_channel_names.append(channels[1][ch].get())
+                self.active_channels.append("AIN{0}".format(ch))
+        self.num_addresses = len(self.active_channels)
+        self.scan_list = namesToAddresses(self.num_addresses, self.active_channels)[0]
+        self.scans_rate = int(sampling["scans_rate"].get())
+        self.scans_per_read = int(sampling["scans_per_read"].get())
+
+        self.new_attributes = [
+                    ("column_names", ", ".join(self.active_channel_names)),
+                    ("units", ", ".join(["V"]*len(self.active_channels))),
+                    ("scans_rate", "{0} [S/s]".format(self.scans_rate))
+               ]
+
+        # shape and type of the array of returned data
+        self.shape =  (self.num_addresses,)
+        self.dtype = 'f'
+
+        self.scan_rate = eStreamStart(self.handle, self.scans_per_read,
+                                      self.num_addresses, self.scan_list,
+                                      self.scans_rate)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        try:
+            eStreamStop(self.handle)
+        except ljm.LJMError as exception:
+            if exception.errorString != "STREAM_NOT_RUNNING":
+                raise
+        ljm.close(self.handle)
+
+    def GetWarnings(self):
+        return None
+
+    def ReadValue(self):
+        # the structures for reading waveform data into
+        data = np.array(eStreamRead(self.handle)[0]).reshape(-1,self.num_addresses)
+        return data
+
+    def DigitalIO5V(self, name, high):
+        """
+        Labjack digital IO is 3.3V, need 5V for the HV PSU. Use open-collector
+        style to get 5V from 3.3V with a pullup to a 5V source.
+        Set the line to input for 5V out.
+        Set the line to output-low for 3.3V out.
+        """
+        if high:
+            eReadName(self.handle, name)
+        else:
+            eWriteName(self.handle, name, 0)
+
+    def HV1Enable(self, enable = 0):
+        # HV enable works as an inhibit; e.g. high signal disables HV
+        name = "FIO0"
+        self.DigitalIO5V(name, not enable)
+        self.hv1_enable = enable
+
+    def HV2Enable(self, enable = 0):
+        # HV enable works as an inhibit; e.g. high signal disables HV
+        name = "FIO1"
+        self.DigitalIO5V(name, not enable)
+        self.hv2_enable = enable
+
+    def SetPolarity(self, polarity1 = "POS", polarity2 = "NEG"):
+        print(polarity1, polarity2)
+
+    def SetVoltage(self, hv1_v, hv2_v, ramp, ramp_time):
+        print(hv1_v, hv2_v, ramp, ramp_time)

--- a/DAQ/drivers/labjackT7.py
+++ b/DAQ/drivers/labjackT7.py
@@ -4,8 +4,7 @@ from labjack.ljm import openS, eReadName, eWriteName, eWriteNames, eStreamStart,
 from labjack import ljm
 import numpy as np
 import time
-import sys
-import datetime
+from threading import Thread
 import logging
 
 class labjackT7:
@@ -13,6 +12,9 @@ class labjackT7:
 
         self.hv1_enable = 0
         self.hv2_enable = 0
+        self.hv1 = 0
+        self.hv2 = 0
+        self.running_ramp = False
         self.handle = openS("T7","ETHERNET",IP_address)
         self.HV1Enable()
         self.HV2Enable()
@@ -58,7 +60,7 @@ class labjackT7:
         self.new_attributes = [
                     ("column_names", ", ".join(self.active_channel_names)),
                     ("units", ", ".join(["V"]*len(self.active_channels))),
-                    ("scans_rate", "{0} [S/s]".format(self.scans_rate))
+                    ("sampling", "{0} [S/s]".format(self.scans_rate))
                ]
 
         # shape and type of the array of returned data
@@ -84,6 +86,9 @@ class labjackT7:
         return None
 
     def ReadValue(self):
+        """
+        Reads ADC values from the analog inputs set to streaming mode.
+        """
         # the structures for reading waveform data into
         data = np.array(eStreamRead(self.handle)[0]).reshape(-1,self.num_addresses)
         return data
@@ -101,19 +106,130 @@ class labjackT7:
             eWriteName(self.handle, name, 0)
 
     def HV1Enable(self, enable = 0):
-        # HV enable works as an inhibit; e.g. high signal disables HV
+        """
+        Enables HV PSU 1.
+        HV PSU has an inhibit input, e.g. high signal disables the PSU
+        """
         name = "FIO0"
         self.DigitalIO5V(name, not enable)
         self.hv1_enable = enable
 
     def HV2Enable(self, enable = 0):
-        # HV enable works as an inhibit; e.g. high signal disables HV
+        """
+        Enables HV PSU 1.
+        HV PSU has an inhibit input, e.g. high signal disables the PSU
+        """
         name = "FIO1"
         self.DigitalIO5V(name, not enable)
         self.hv2_enable = enable
 
     def SetPolarity(self, polarity1 = "POS", polarity2 = "NEG"):
+        """
+        Set polarities of HV PSU 1 & 2, requires them to be at 0 kV.
+        """
+        if (self.hv1 != 0) and (self.hv2 != 0):
+            logging.warning("labjackT7 error: Voltages not zero, cannot switch polarities")
+            return
         print(polarity1, polarity2)
 
+    def SetHV1(self, hv1):
+        """
+        Set voltage of HV PSU 1.
+        Sets output voltage of LJTick-DAC from 0-10 V, corresponding to 0-30kV
+        """
+        if not ((hv1 <= 30) & (hv1 >= 0)):
+            logging.warning("labjackT7 error: Set Voltage HV1 out of range 0-30kV")
+            return
+        if self.hv1 == hv1:
+            return
+        elif not self.hv1_enable:
+            logging.warning("labjackT7 error: HV1 not enabled")
+            return
+        elif not self.hv1 == hv1:
+            print("HV1 : ",hv1)
+            self.hv1 = hv1
+
+    def SetHV2(self, hv2):
+        """
+        Set voltage of HV PSU 2.
+        Sets output voltage of LJTick-DAC from 0-10 V, corresponding to 0-30kV
+        """
+        if not ((hv2 <= 30) & (hv2 >= 0)):
+            logging.warning("labjackT7 error: Set Voltage HV2 out of range 0-30kV")
+            return
+        if self.hv2 == hv2:
+            return
+        elif not self.hv2_enable:
+            logging.warning("labjackT7 error: HV2 not enabled")
+            return
+        elif not self.hv2 == hv2:
+            print("HV2 : ",hv2)
+            self.hv2 = hv2
+
     def SetVoltage(self, hv1_v, hv2_v, ramp, ramp_time):
-        print(hv1_v, hv2_v, ramp, ramp_time)
+        """
+        Set voltages of HV PSU 1 & 2, capable of 0-30 kV.
+        Polarity is set in another function, only possible when voltages are zero.
+        """
+        try:
+            hv1_v = float(hv1_v)
+            hv2_v = float(hv2_v)
+            ramp = int(ramp)
+            ramp_time = float(ramp_time)
+        except Exception as e:
+            logging.warning("labjackT7 error: {0}".format(e))
+            return
+
+        if (not self.hv1_enable) & (self.hv1 != hv1_v):
+            logging.warning("labjackT7 error: HV1 not enabled")
+            return
+        if (not self.hv2_enable) & (self.hv2 != hv2_v):
+            logging.warning("labjackT7 error: HV2 not enabled")
+            return
+        if not ((hv1_v <= 30) & (hv1_v >= 0)):
+            logging.warning("labjackT7 error: Set Voltage HV1 out of range 0-30kV")
+            return
+        if not ((hv2_v <= 30) & (hv2_v >= 0)):
+            logging.warning("labjackT7 error: Set Voltage HV2 out of range 0-30kV")
+            return
+
+        # Check if threaded ramp is already running, if yes exit SetVoltage
+        if self.running_ramp:
+            logging.warning("labjackT7 error: Currently running voltage ramp")
+            return
+        # Check if voltages are already set
+        elif (self.hv1 == hv1_v) and (self.hv2 == hv2_v):
+            logging.warning("labjackT7 error: Voltages already set")
+        # Start threaded ramp function if ramping
+        elif ramp:
+            thread = Thread(target = self.RampVoltageSet, args = (hv1_v, hv2_v, ramp, ramp_time))
+            thread.start()
+
+        else:
+            self.SetHV1(hv1_v)
+            self.SetHV2(hv2_v)
+
+    def RampVoltageSet(self, hv1_v, hv2_v, ramp, ramp_time):
+        """
+        Voltage ramping function
+        """
+        self.running_ramp = True
+        if ramp_time == 0:
+            logging.warning("labjackT7 error: Ramp time is zero")
+            self.running_ramp = False
+            return
+        hv1_start = self.hv1
+        hv2_start = self.hv2
+        dv1 = hv1_v-hv1_start
+        dv2 = hv2_v-hv2_start
+        dt = 0.05
+        dv1dt = (dv1/ramp_time)*dt
+        dv2dt = (dv2/ramp_time)*dt
+        steps = int(ramp_time/dt)
+        for i in range(steps):
+            self.SetHV1(hv1_start+dv1dt*i)
+            self.SetHV2(hv2_start+dv2dt*i)
+            time.sleep(dt)
+        self.SetHV1(hv1_v)
+        self.SetHV2(hv2_v)
+        self.running_ramp = False

--- a/DAQ/main.py
+++ b/DAQ/main.py
@@ -64,7 +64,7 @@ class Device(threading.Thread):
             else:
                 self.constr_params.append( self.config["controls"][cp]["var"].get() )
 
-        with self.config["driver"](*self.constr_params) as dev: 
+        with self.config["driver"](*self.constr_params) as dev:
             # verify the device responds correctly
             if dev.verification_string.strip() == self.config["correct_response"].strip():
                 self.operational = True
@@ -91,7 +91,7 @@ class Device(threading.Thread):
             self.control_started = True
 
         # main control loop
-        with self.config["driver"](*self.constr_params) as device: 
+        with self.config["driver"](*self.constr_params) as device:
             while self.active.is_set():
                 # loop delay
                 try:
@@ -110,7 +110,7 @@ class Device(threading.Thread):
 
                 # record numerical values
                 last_data = device.ReadValue()
-                if last_data:
+                if  len(last_data) > 0:
                     self.data_queue.append(last_data)
 
                 # keep track of the number of NaN returns
@@ -387,7 +387,7 @@ class ControlGUI(tk.Frame):
             fd = tk.LabelFrame(self.fr, text=dev.config["label"])
             fd.grid(padx=10, pady=10, sticky="nsew",
                     row=dev.config["row"], column=dev.config["column"],
-                    rowspan=dev.config["rowspan"], columnspan=dev.config["columnspan"]) 
+                    rowspan=dev.config["rowspan"], columnspan=dev.config["columnspan"])
 
             # the button to reload attributes
             attr_b = tk.Button(fd, text="Attrs", command=lambda dev=dev: self.reload_attrs(dev))
@@ -454,6 +454,7 @@ class ControlGUI(tk.Frame):
                     c["Frame"].grid(row=c["row"], column=c["col"], sticky='w', pady=10)
                     c["Label"] = tk.Label(fd, text=c["label"])
                     c["Label"].grid(row=c["row"], column=c["col"]-1, sticky=tk.E)
+                    controls_row_args = dict((name, c["control_values"][name]) for name in c["control_names"] if c["control_values"][name].get() != '')
                     for i, name in enumerate(c["control_names"]):
                         c["ctrls"] = {}
                         if c["control_types"][i] == "Entry":
@@ -461,14 +462,23 @@ class ControlGUI(tk.Frame):
                                     width=c["control_widths"][i], textvariable=c["control_values"][name])
                         elif c["control_types"][i] == "Button":
                             c["ctrls"][name] = tk.Button(
-                                    c["Frame"],
+                                    c["Frame"], width = c["control_widths"][i],
                                     text=c["control_values"][name].get(),
-                                    command=lambda dev=dev,
-                                        cmd=c["control_commands"][i]+"()": self.queue_command(dev, cmd)
+                                    command=lambda dev=dev, args = controls_row_args,
+                                        cmd=c["control_commands"][i]: self.queue_command(dev, cmd+"(**"+str(dict((n,v.get()) for n,v in args.items()))+")")
                                 )
                         elif c["control_types"][i] == "OptionMenu":
                             c["ctrls"][name] = tk.OptionMenu(c["Frame"],
                                     c["control_values"][name], *c["control_options"][i])
+                        elif c["control_types"][i] == "Checkbutton":
+                            c["ctrls"][name] = \
+                            tk.Checkbutton(c["Frame"], variable=c["control_values"][name])
+                        elif c["control_types"][i] == "CheckbuttonCmd":
+                            c["ctrls"][name] = \
+                            tk.Checkbutton(c["Frame"], variable=c["control_values"][name],
+                                           command=lambda dev=dev, arg = c["control_values"][name],
+                                           cmd=c["control_commands"][i]: self.queue_command(dev, cmd+"("+arg.get()+")"))
+
                         c["ctrls"][name].grid(row=1, column=i+1, sticky="nsew", padx=5)
                         tk.Label(c["Frame"], text=c["control_labels"][i])\
                                 .grid(row=0, column=i+1)


### PR DESCRIPTION
Added support for arbitrary x-axis selection in the plot section.
If a time column exists it will plot against that by default; otherwise the default assumes the device has an attribute sampling, with the sampling rate expressed as "# [S/s]", which is employed to create the x coordinates for the plot.
Any arbitrary column of the HDF is selectable for the x coordinate of the plot; it pulls the units from the attributes of the HDF dataset.

Also contains rudimentary support for the labjack T7 Pro used in electrostatic lens acquisition and control. Continuous streaming is fully functional, still working on control.