### PR TITLE
First version of Socket Client-Server communication

### DIFF
--- a/drivers/FS740.py
+++ b/drivers/FS740.py
@@ -49,9 +49,9 @@ class FS740:
 
         self.verification_string = self.VerifyOperation()
         if not isinstance(self.verification_string, str):
-            self.verification_string = False
+            self.verification_string = 'False'
         self.new_attributes = []
-        self.dtype = 'f16'
+        self.dtype = 'f8'
         self.shape = (6,)
 
         self.warnings = []
@@ -60,7 +60,10 @@ class FS740:
         return self
 
     def __exit__(self, *exc):
-        self.instr.close()
+        try:
+            self.instr.close()
+        except:
+            pass
 
     def query(self, cmd):
         return self.instr.query(cmd)
@@ -75,7 +78,7 @@ class FS740:
 
     def ReadValue(self):
         self.WriteValueINFLUXDB()
-        return [
+        values = [
                 time.time() - self.time_offset,
                 float(self.TBaseStateLockDuration()),
                 float(self.TBaseTInterval()),
@@ -83,6 +86,7 @@ class FS740:
                 float(self.QueryTBaseTConstant()),
                 float(self.QueryTBaseFControl()),
         ]
+        return values
 
     def ReadValueINFLUXDB(self, full_output = False):
         date = self.QuerySystemDate()

--- a/drivers/SocketDeviceClient.py
+++ b/drivers/SocketDeviceClient.py
@@ -1,0 +1,366 @@
+import sys
+import importlib
+import socket
+import selectors
+import traceback
+import random
+import logging
+import json
+import io
+import struct
+import numpy as np
+import inspect
+import functools
+import time
+from types import FunctionType
+
+#############################################
+# Class for client side messages
+#############################################
+
+class ClientMessage:
+    """
+    ClientMessage class for communication between the SocketDeviceServer and
+    SocketDeviceClient classes.
+    A message has the following structure:
+    - fixed-lenght header
+    - json header
+    - content
+    See https://realpython.com/python-sockets/#application-client-and-server
+    for a more thorough explanation, most of the code is adapted fromt this.
+    """
+    def __init__(self, selector, sock, addr, request):
+        self.selector = selector
+        self.sock = sock
+        self.addr = addr
+        self.request = request
+        self._recv_buffer = b""
+        self._send_buffer = b""
+        self._request_queued = False
+        self._jsonheader_len = None
+        self.jsonheader = None
+        self.response = None
+        self.result = np.nan
+
+    def _set_selector_events_mask(self, mode):
+        """Set selector to listen for events: mode is 'r', 'w', or 'rw'."""
+        if mode == "r":
+            events = selectors.EVENT_READ
+        elif mode == "w":
+            events = selectors.EVENT_WRITE
+        elif mode == "rw":
+            events = selectors.EVENT_READ | selectors.EVENT_WRITE
+        else:
+            raise ValueError(f"Invalid events mask mode {repr(mode)}.")
+        self.selector.modify(self.sock, events, data=self)
+
+    def _read(self):
+        try:
+            # Should be ready to read
+            data = self.sock.recv(4096)
+        except BlockingIOError:
+            # Resource temporarily unavailable (errno EWOULDBLOCK)
+            pass
+        else:
+            if data:
+                self._recv_buffer += data
+            else:
+                raise RuntimeError("Peer closed.")
+
+    def _write(self):
+        if self._send_buffer:
+            try:
+                # Should be ready to write
+                sent = self.sock.send(self._send_buffer)
+            except BlockingIOError:
+                # Resource temporarily unavailable (errno EWOULDBLOCK)
+                pass
+            else:
+                self._send_buffer = self._send_buffer[sent:]
+
+    def _json_encode(self, obj, encoding):
+        return json.dumps(obj, ensure_ascii=False).encode(encoding)
+
+    def _json_decode(self, json_bytes, encoding):
+        tiow = io.TextIOWrapper(
+            io.BytesIO(json_bytes), encoding=encoding, newline=""
+        )
+        obj = json.load(tiow)
+        tiow.close()
+        return obj
+
+    def _create_message(
+        self, *, content_bytes, content_type, content_encoding
+    ):
+        jsonheader = {
+            "byteorder": sys.byteorder,
+            "content-type": content_type,
+            "content-encoding": content_encoding,
+            "content-length": len(content_bytes),
+        }
+        jsonheader_bytes = self._json_encode(jsonheader, "utf-8")
+        message_hdr = struct.pack(">H", len(jsonheader_bytes))
+        message = message_hdr + jsonheader_bytes + content_bytes
+        return message
+
+    def _process_response_json_content(self):
+        content = self.response
+        if content.get("result"):
+            self.result = content.get("result")
+        else:
+            self.result = np.nan
+            raise ValueError(content.get('error'))
+
+    def _process_response_binary_content(self):
+        content = self.response
+        print(f"got response: {repr(content)}")
+
+    def process_events(self, mask):
+        if mask & selectors.EVENT_READ:
+            self.read()
+        if mask & selectors.EVENT_WRITE:
+            self.write()
+
+    def read(self):
+        self._read()
+
+        if self._jsonheader_len is None:
+            self.process_protoheader()
+
+        if self._jsonheader_len is not None:
+            if self.jsonheader is None:
+                self.process_jsonheader()
+
+        if self.jsonheader:
+            if self.response is None:
+                self.process_response()
+
+    def write(self):
+        if not self._request_queued:
+            self.queue_request()
+
+        self._write()
+
+        if self._request_queued:
+            if not self._send_buffer:
+                # Set selector to listen for read events, we're done writing.
+                self._set_selector_events_mask("r")
+
+    def close(self):
+        try:
+            self.selector.unregister(self.sock)
+        except Exception as e:
+            logging.warning(
+                f"error: selector.unregister() exception for",
+                f"{self.addr}: {repr(e)}",
+            )
+
+        try:
+            self.sock.close()
+        except OSError as e:
+            logging.warning(
+                f"error: socket.close() exception for",
+                f"{self.addr}: {repr(e)}",
+            )
+        finally:
+            # Delete reference to socket object for garbage collection
+            self.sock = None
+
+    def queue_request(self):
+        content = self.request["content"]
+        content_type = self.request["type"]
+        content_encoding = self.request["encoding"]
+        if content_type == "text/json":
+            req = {
+                "content_bytes": self._json_encode(content, content_encoding),
+                "content_type": content_type,
+                "content_encoding": content_encoding,
+            }
+        else:
+            req = {
+                "content_bytes": content,
+                "content_type": content_type,
+                "content_encoding": content_encoding,
+            }
+        message = self._create_message(**req)
+        self._send_buffer += message
+        self._request_queued = True
+
+    def process_protoheader(self):
+        hdrlen = 2
+        if len(self._recv_buffer) >= hdrlen:
+            self._jsonheader_len = struct.unpack(
+                ">H", self._recv_buffer[:hdrlen]
+            )[0]
+            self._recv_buffer = self._recv_buffer[hdrlen:]
+
+    def process_jsonheader(self):
+        hdrlen = self._jsonheader_len
+        if len(self._recv_buffer) >= hdrlen:
+            self.jsonheader = self._json_decode(
+                self._recv_buffer[:hdrlen], "utf-8"
+            )
+            self._recv_buffer = self._recv_buffer[hdrlen:]
+            for reqhdr in (
+                "byteorder",
+                "content-length",
+                "content-type",
+                "content-encoding",
+            ):
+                if reqhdr not in self.jsonheader:
+                    raise ValueError(f'Missing required header "{reqhdr}".')
+
+    def process_response(self):
+        content_len = self.jsonheader["content-length"]
+        if not len(self._recv_buffer) >= content_len:
+            return
+        data = self._recv_buffer[:content_len]
+        self._recv_buffer = self._recv_buffer[content_len:]
+        if self.jsonheader["content-type"] == "text/json":
+            encoding = self.jsonheader["content-encoding"]
+            self.response = self._json_decode(data, encoding)
+            self._process_response_json_content()
+        else:
+            # Binary or unknown content-type
+            self.response = data
+            self._process_response_binary_content()
+        # Close when response has been processed
+        self.close()
+
+#############################################
+# Socket Device Client Class
+#############################################
+
+def wrapperSocketClientMethods(func):
+    """
+    Function wrapper for all methods of the device driver class excluding static
+    methods, __**__ methods and ReadValue.
+    Wraps device driver methods to function with the socket client.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        device_name = args[0].device_name
+        value = args[0].request("command", func.__name__+'(*{0}, **{1})'.format(args[1:], kwargs))
+        try:
+            if np.isnan(value):
+                logging.warning("SocketClient warning in {0}: cannot connect to server".format(func.__name__))
+                return np.nan
+        except Exception:
+            pass
+        if func.__name__ not in  value[1]:
+            logging.warning("{1} socket warning in {0}: wrong function return".format(func.__name__, device_name))
+            return np.nan
+        elif "not executed" in value[2]:
+            logging.warning("{2} socket warning in {0}: {1}".format(func.__name__, value[2], device_name))
+            return np.nan
+        elif "Exception" in value[2]:
+            logging.warning("{2} socket warning in {0}: {1}".format(func.__name__, value[2], device_name))
+            return np.nan
+        return value[2]
+    return wrapper
+
+def wrapperReadValueClientMethod(func):
+    """
+    Function wrapper for the ReadValue method of the device driver class to
+    ensure compatibility with the socket client
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        value = args[0].request("query", "ReadValue")
+        v = [value[0]-args[0].time_offset]
+        v.extend(value[1])
+        return v
+    return wrapper
+
+def ClientClassDecorator(cls):
+    """
+    Decorator fot the SocketDeviceClientClass to modify driver function for use
+    with the socket client.
+    """
+    for attr_name in dir(cls):
+        attr_value = getattr(cls, attr_name)
+        if isinstance(attr_value, FunctionType):
+            if attr_name == 'ReadValue':
+                attribute = wrapperReadValueClientMethod(attr_value)
+                setattr(cls, attr_name, attribute)
+            elif attr_name in ['__init__', '_createRequest', 'request', '__enter__', '__exit__']:
+                continue
+            elif not inspect.signature(attr_value).parameters.get('self'):
+                # don't wrap static methods, very clunky method but couldn't
+                # figure out a better way
+                continue
+            else:
+                attribute = wrapperSocketClientMethods(attr_value)
+                setattr(cls, attr_name, attribute)
+    return cls
+
+def SocketDeviceClient(*args):
+    """
+    Function returns the SocketDeviceClient class which functions as a driver.
+    Need to do it this way because the parent class is a driver class, dynamically
+    loaded when the SocketDeviceClient function is called from the main DAQ
+    software.
+    """
+    driver = args[2]
+    driver_spec = importlib.util.spec_from_file_location(
+            driver,
+            "drivers/" + driver + ".py",
+        )
+    driver_module = importlib.util.module_from_spec(driver_spec)
+    driver_spec.loader.exec_module(driver_module)
+    driver = getattr(driver_module, driver)
+
+    @ClientClassDecorator
+    class SocketDeviceClientClass(driver):
+        """
+        SocketDeviceClient template class for easy setup of specific device classes
+        """
+        def __init__(self, time_offset, socket_connection, device_name, *device_args):
+            self.device_name = device_name
+            device_args = [eval(_) for _ in device_args]
+            self.host = socket_connection['host']
+            self.port = int(socket_connection['port'])
+            driver.__init__(self, time_offset, *device_args)
+
+        def _createRequest(self, action, value):
+            return dict(
+                type="text/json",
+                encoding="utf-8",
+                content=dict(action=action, value=value),
+            )
+
+        def request(self, action, value):
+            """
+            Send a request to the SocketDeviceServer
+            """
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setblocking(False)
+            con = sock.connect_ex((self.host, self.port))
+            sel = selectors.DefaultSelector()
+            request = self._createRequest(action, value)
+            message = ClientMessage(sel, sock, (self.host, sock), request)
+            events = selectors.EVENT_READ | selectors.EVENT_WRITE
+            sel.register(sock, events, data=message)
+
+            try:
+                while True:
+                    events = sel.select(timeout=1)
+                    for key, mask in events:
+                        message = key.data
+                        try:
+                            message.process_events(mask)
+                        except Exception as err:
+                            logging.warning("{0} socket warning in request: ".format(self.device_name)
+                                           +str(err))
+                            message.close()
+                    # Check for a socket being monitored to continue.
+                    if not sel.get_map():
+                        break
+            except Exception as e:
+                logging.warning('{0} socket warning in request: '.format(self.device_name)+str(e))
+                return np.nan
+            finally:
+                sel.close()
+                return message.result
+
+    return SocketDeviceClientClass(*args)

--- a/drivers/SocketDeviceServer.py
+++ b/drivers/SocketDeviceServer.py
@@ -1,0 +1,431 @@
+import importlib
+import sys
+import socket
+import selectors
+import traceback
+import threading
+from collections import deque
+import random
+import logging
+import time
+from types import FunctionType
+import functools
+import json
+import io
+import struct
+import inspect
+from queue import Queue
+import numpy as np
+
+#############################################
+# Class for server side messages
+#############################################
+
+class ServerMessage:
+    """
+    ServerMessage class for communication between the SocketDeviceServer and
+    SocketDeviceClient classes.
+    A message has the following structure:
+    - fixed-lenght header
+    - json header
+    - content
+    See https://realpython.com/python-sockets/#application-client-and-server
+    for a more thorough explanation, most of the code is adapted from this.
+    """
+    def __init__(self, selector, sock, addr, data, commands, timeout):
+        self.selector = selector
+        self.sock = sock
+        self.addr = addr
+        self._recv_buffer = b""
+        self._send_buffer = b""
+        self._jsonheader_len = None
+        self.jsonheader = None
+        self.request = None
+        self.response_created = False
+
+        self.data = data
+        self.commands = commands
+        self.timeout = timeout
+
+    def _set_selector_events_mask(self, mode):
+        """Set selector to listen for events: mode is 'r', 'w', or 'rw'."""
+        if mode == "r":
+            events = selectors.EVENT_READ
+        elif mode == "w":
+            events = selectors.EVENT_WRITE
+        elif mode == "rw":
+            events = selectors.EVENT_READ | selectors.EVENT_WRITE
+        else:
+            raise ValueError(f"Invalid events mask mode {repr(mode)}.")
+        self.selector.modify(self.sock, events, data=self)
+
+    def _read(self):
+        try:
+            # Should be ready to read
+            data = self.sock.recv(4096)
+        except BlockingIOError:
+            # Resource temporarily unavailable (errno EWOULDBLOCK)
+            pass
+        else:
+            if data:
+                self._recv_buffer += data
+            else:
+                raise RuntimeError("Peer closed.")
+
+    def _write(self):
+        if self._send_buffer:
+            try:
+                # Should be ready to write
+                sent = self.sock.send(self._send_buffer)
+            except BlockingIOError:
+                # Resource temporarily unavailable (errno EWOULDBLOCK)
+                pass
+            else:
+                self._send_buffer = self._send_buffer[sent:]
+                # Close when the buffer is drained. The response has been sent.
+                if sent and not self._send_buffer:
+                    self.close()
+
+    def _json_encode(self, obj, encoding):
+        return json.dumps(obj, ensure_ascii=False).encode(encoding)
+
+    def _json_decode(self, json_bytes, encoding):
+        tiow = io.TextIOWrapper(
+            io.BytesIO(json_bytes), encoding=encoding, newline=""
+        )
+        obj = json.load(tiow)
+        tiow.close()
+        return obj
+
+    def _create_message(
+        self, *, content_bytes, content_type, content_encoding
+    ):
+        jsonheader = {
+            "byteorder": sys.byteorder,
+            "content-type": content_type,
+            "content-encoding": content_encoding,
+            "content-length": len(content_bytes),
+        }
+        jsonheader_bytes = self._json_encode(jsonheader, "utf-8")
+        message_hdr = struct.pack(">H", len(jsonheader_bytes))
+        message = message_hdr + jsonheader_bytes + content_bytes
+        return message
+
+    def _create_response_json_content(self):
+        action = self.request.get("action")
+        if action == "query":
+            query = self.request.get("value")
+            if self.data.get(query):
+                content = {"result": self.data.get(query)}
+            else:
+                content = {"error": f'No match for "{query}".'}
+        elif action == "command":
+            command = self.request.get("value")
+            tstart = time.time()
+            self.commands.put(command)
+            while True:
+                if self.data["commandReturn"].get(command):
+                    content = {"result": self.data["commandReturn"].get(command)}
+                    del self.data["commandReturn"][command]
+                    break
+                # manual timeout if it takes to long to execute command
+                # subsequently returns to the client a message stating function
+                # execution took too much time
+                elif time.time() - tstart > self.timeout:
+                    content = {"result": (time.time(), command, "not executed, {0}s timeout".format(self.timeout))}
+                    break
+        else:
+            content = {"error": f'invalid action "{action}".'}
+        content_encoding = "utf-8"
+        response = {
+            "content_bytes": self._json_encode(content, content_encoding),
+            "content_type": "text/json",
+            "content_encoding": content_encoding,
+        }
+        return response
+
+    def _create_response_binary_content(self):
+        response = {
+            "content_bytes": b"First 10 bytes of request: "
+            + self.request[:10],
+            "content_type": "binary/custom-server-binary-type",
+            "content_encoding": "binary",
+        }
+        return response
+
+    def process_events(self, mask):
+        if mask & selectors.EVENT_READ:
+            self.read()
+        if mask & selectors.EVENT_WRITE:
+            self.write()
+
+    def read(self):
+        self._read()
+
+        if self._jsonheader_len is None:
+            self.process_protoheader()
+
+        if self._jsonheader_len is not None:
+            if self.jsonheader is None:
+                self.process_jsonheader()
+
+        if self.jsonheader:
+            if self.request is None:
+                self.process_request()
+
+    def write(self):
+        if self.request:
+            if not self.response_created:
+                self.create_response()
+
+        self._write()
+
+    def close(self):
+        try:
+            self.selector.unregister(self.sock)
+        except Exception as e:
+            logging.warning(
+                f"error: selector.unregister() exception for",
+                f"{self.addr}: {repr(e)}",
+            )
+
+        try:
+            self.sock.close()
+        except OSError as e:
+            logging.warning(
+                f"error: socket.close() exception for",
+                f"{self.addr}: {repr(e)}",
+            )
+        finally:
+            # Delete reference to socket object for garbage collection
+            self.sock = None
+
+    def process_protoheader(self):
+        hdrlen = 2
+        if len(self._recv_buffer) >= hdrlen:
+            self._jsonheader_len = struct.unpack(
+                ">H", self._recv_buffer[:hdrlen]
+            )[0]
+            self._recv_buffer = self._recv_buffer[hdrlen:]
+
+    def process_jsonheader(self):
+        hdrlen = self._jsonheader_len
+        if len(self._recv_buffer) >= hdrlen:
+            self.jsonheader = self._json_decode(
+                self._recv_buffer[:hdrlen], "utf-8"
+            )
+            self._recv_buffer = self._recv_buffer[hdrlen:]
+            for reqhdr in (
+                "byteorder",
+                "content-length",
+                "content-type",
+                "content-encoding",
+            ):
+                if reqhdr not in self.jsonheader:
+                    raise ValueError(f'Missing required header "{reqhdr}".')
+
+    def process_request(self):
+        content_len = self.jsonheader["content-length"]
+        if not len(self._recv_buffer) >= content_len:
+            return
+        data = self._recv_buffer[:content_len]
+        self._recv_buffer = self._recv_buffer[content_len:]
+        if self.jsonheader["content-type"] == "text/json":
+            encoding = self.jsonheader["content-encoding"]
+            self.request = self._json_decode(data, encoding)
+        else:
+            # Binary or unknown content-type
+            self.request = data
+        # Set selector to listen for write events, we're done reading.
+        self._set_selector_events_mask("w")
+
+    def create_response(self):
+        if self.jsonheader["content-type"] == "text/json":
+            response = self._create_response_json_content()
+        else:
+            # Binary or unknown content-type
+            response = self._create_response_binary_content()
+        message = self._create_message(**response)
+        self.response_created = True
+        self._send_buffer += message
+
+#############################################
+# Socket Server Class
+#############################################
+
+class socketServer(threading.Thread):
+    """
+    Handles communication with external clients in a separate thread.
+    """
+    def __init__(self, device, host, port, timeout):
+        threading.Thread.__init__(self)
+        self.device = device
+        self.host = ''
+        self.timeout = float(timeout)
+        self.port = int(port)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind((self.host, self.port))
+        self.sock.listen()
+        self.sock.setblocking(False)
+        self.sel = selectors.DefaultSelector()
+        self.sel.register(self.sock, selectors.EVENT_READ, data=None)
+
+        self.active = threading.Event()
+        self.active.clear()
+
+    def accept_wrapper(self, sock):
+        conn, addr = sock.accept()  # Should be ready to read
+        logging.info("{0} accepted connection from".format(self.device.device_name), addr)
+        conn.setblocking(False)
+        message = ServerMessage(self.sel, conn, addr, self.device.data,
+                                self.device.commands, self.timeout)
+        self.sel.register(conn, selectors.EVENT_READ, data=message)
+
+    def run(self):
+        self.active.set()
+        while self.active.is_set():
+            events = self.sel.select(timeout = self.timeout)
+            for key, mask in events:
+                if key.data is None:
+                    self.accept_wrapper(key.fileobj)
+                else:
+                    message = key.data
+                    try:
+                        message.process_events(mask)
+                    except Exception as err:
+                        logging.warning("{2} socket warning for "
+                                       +"{0}:{1} : ".format(self.host, self.port, self.device.device_name)
+                                       +str(err))
+                        message.close()
+
+#############################################
+# Execute Commands Class
+#############################################
+
+class executeCommands(threading.Thread):
+    """
+    Handles executing commands from external clients in a separate thread.
+    """
+    def __init__(self, device):
+        threading.Thread.__init__(self)
+        self.device = device
+        self.commands = device.commands
+        self.data = device.data
+
+        self.active = threading.Event()
+        self.active.clear()
+
+    def run(self):
+        self.active.set()
+        while self.active.is_set():
+            # check if any new commands
+            if not self.commands.empty():
+                c = self.commands.get()
+                try:
+                    # try to execute the command
+                    value = eval('self.device.'+c.strip())
+                    # storing command in the server device database
+                    self.data['commandReturn'][c] = (time.time(), c, value)
+                except Exception as e:
+                    self.data['commandReturn'][c] = (time.time(), c, 'Exception: '+str(e))
+                    pass
+            time.sleep(5e-3)
+
+#############################################
+# Socket Device Server Class
+#############################################
+
+def wrapperReadValueServerMethod(func):
+    """
+    Wraps the ReadValue method of a device driver.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        value = func(*args, **kwargs)
+        args[0].data['ReadValue'] = (time.time(), value[1:])
+        return value
+    return wrapper
+
+def ServerClassDecorator(cls):
+    """
+    Decorator for the SocketDeviceServerClass to modify driver functions for use
+    with a socket server.
+    """
+    for attr_name in dir(cls):
+        attr_value = getattr(cls, attr_name)
+        if isinstance(attr_value, FunctionType):
+            if attr_name == 'ReadValue':
+                attribute = wrapperReadValueServerMethod(attr_value)
+                setattr(cls, attr_name, attribute)
+            elif attr_name in ['__init__', 'accept_wrapper', 'run_server', '__enter__', '__exit__']:
+                continue
+            elif not inspect.signature(attr_value).parameters.get('self'):
+                # don't wrap static methods, very clunky method but couldn't
+                # figure out a better way
+                continue
+            else:
+                continue
+                # attribute = wrapperSocketServerMethods(attr_value)
+                # setattr(cls, attr_name, attribute)
+    return cls
+
+def SocketDeviceServer(*args):
+    """
+    Function returns the SocketDeviceServer class which functions as a driver.
+    Need to do it this way because the parent class is a driver class, dynamically
+    loaded when the SocketDeviceServer function is called from the main DAQ
+    software.
+    """
+    driver = args[2]
+    driver_spec = importlib.util.spec_from_file_location(
+            driver,
+            "drivers/" + driver + ".py",
+        )
+    driver_module = importlib.util.module_from_spec(driver_spec)
+    driver_spec.loader.exec_module(driver_module)
+    driver = getattr(driver_module, driver)
+
+    @ServerClassDecorator
+    class SocketDeviceServerClass(driver):
+        """
+        SocketDeviceServer template class for easy setup of specific device classes
+        """
+        def __init__(self, time_offset, port, device_name, timeout, *device_args):
+            self.device_name = device_name
+            # initializing the server device database
+            self.verification_string = 'False'
+            self.data = {'ReadValue':np.nan, 'verification':self.verification_string,
+                         'commandReturn':{}}
+
+            # server commands queue for storing commands of external clients
+            self.commands = Queue()
+
+            # start thread responsible for executing commands from external
+            # clients
+            self.thread_device = executeCommands(self)
+            self.thread_device.start()
+
+            # initialize the device driver
+            driver.__init__(self, time_offset, *device_args)
+            # add verification string to the server device database
+            self.data['verification'] = self.verification_string
+
+            # starting the thread responsible for handling communication with
+            # external clients
+            self.thread_server = socketServer(self, '', int(port), float(timeout))
+            self.thread_server.start()
+            # sleeping for the same amount of time as the server communication
+            # timeout to prevent problems when initializing the class twice
+            # in the main DAQ software
+            time.sleep(float(timeout))
+
+        def __exit__(self, *exc):
+            """
+            Properly stopping the communication and command execution threads.
+            """
+            self.thread_device.active.clear()
+            self.thread_server.active.clear()
+            super(SocketDeviceServerClass, self).__exit__(*exc)
+
+    return SocketDeviceServerClass(*args)


### PR DESCRIPTION
SocketDeviceClient and SocketDeviceServer wrap a driver class for server side and client side communication between different computers (or on the same computer).

Due to the way the main DAQ program works they can't run in the same main instance (only an issue when running on the same computer). This is because some drivers call class methods in __init__which are wrapped to function with sockets, but initially the drivers are just initialized one by one to check if the connection is valid. Then the client tries to connect to the server class in order to execute those functions, but there is no server listening, resulting in a crashing DAQ program.